### PR TITLE
feat: Add zkvm precompile for G1Affine addition

### DIFF
--- a/.github/workflows/check-downstream-compiles.yml
+++ b/.github/workflows/check-downstream-compiles.yml
@@ -24,6 +24,13 @@ jobs:
       - uses: ./ci-workflows/.github/actions/install-deps
         with:
           packages: "pkg-config libudev-dev"
+      - name: Install cargo-prove and WP1 toolchain
+        run: |
+          git clone https://github.com/wormhole-foundation/wp1.git
+          cd wp1/cli
+          cargo install --locked --path .
+          cd ~
+          cargo prove install-toolchain
       - uses: Swatinem/rust-cache@v2
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run tests
         run: cargo test --verbose --release --features experimental,zeroize
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
 
   wasm:
     name: Check wasm target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
       - uses: actions/checkout@v3
       - name: Run tests
         run: cargo test --verbose --release --features experimental,zeroize
@@ -23,6 +27,10 @@ jobs:
           - wasm32-unknown-unknown
           - wasm32-wasi
     steps:
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
       - uses: actions/checkout@v3
       - run: rustup target add ${{ matrix.target }}
       - run: cargo fetch
@@ -38,6 +46,10 @@ jobs:
     name: Bitrot check
     runs-on: ubuntu-latest
     steps:
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
       - uses: actions/checkout@v3
       # Build benchmarks and all-features to prevent bitrot
       - name: Build benchmarks
@@ -47,6 +59,10 @@ jobs:
     name: Intra-doc links
     runs-on: ubuntu-latest
     steps:
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
       - uses: actions/checkout@v3
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crate.
@@ -58,6 +74,10 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
       - uses: actions/checkout@v3
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ required-features = ["experimental"]
 [dependencies]
 cfg-if = "1.0.0"
 
+[target.'cfg(target_os = "zkvm")'.dependencies]
+wp1-precompiles = { git = "ssh://git@github.com/wormhole-foundation/wp1", branch = "dev" }
+
 [dependencies.digest]
 version = "0.9"
 optional = true

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -657,7 +657,10 @@ impl Fp {
     #[cfg(target_os = "zkvm")]
     pub(crate) fn mul_r_inv_internal(&mut self) {
         unsafe {
-            wp1_precompiles::syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, R_INV.0.as_ptr() as *const u32);
+            wp1_precompiles::syscall_bls12381_fp_mul(
+                self.0.as_mut_ptr() as *mut u32,
+                R_INV.0.as_ptr() as *const u32,
+            );
         }
     }
 
@@ -667,7 +670,10 @@ impl Fp {
     #[cfg(target_os = "zkvm")]
     pub(crate) fn mul_r_internal(&mut self) {
         unsafe {
-            wp1_precompiles::syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, R.0.as_ptr() as *const u32);
+            wp1_precompiles::syscall_bls12381_fp_mul(
+                self.0.as_mut_ptr() as *mut u32,
+                R.0.as_ptr() as *const u32,
+            );
         }
     }
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -12,7 +12,7 @@ use crate::util::{adc, mac, sbb};
 // integers in little-endian order. `Fp` values are always in
 // Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
 #[derive(Copy, Clone)]
-#[repr(transparent)] // NOTE: this might be *technically* required for ensuring the memory layout used in the zkvm is valid?
+#[repr(transparent)] // NOTE: this is technically required for ensuring the memory layout used in the zkvm precompiles is valid
 pub struct Fp(pub(crate) [u64; 6]);
 
 impl fmt::Debug for Fp {

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -601,7 +601,8 @@ impl Fp {
                 unsafe {
                     wp1_precompiles::syscall_bls12381_fp_mul(out.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
                 }
-                out.mul_r_inv_internal()
+                out.mul_r_inv_internal();
+                out
             } else {
                 let (t0, carry) = mac(0, self.0[0], rhs.0[0], 0);
                 let (t1, carry) = mac(0, self.0[0], rhs.0[1], carry);
@@ -654,22 +655,20 @@ impl Fp {
     /// the internal Montgomery form to a plain BigInt form.
     /// Used as a bridge between the internal Montgomery representation and the zkvm precompiles.
     #[cfg(target_os = "zkvm")]
-    pub(crate) fn mul_r_inv_internal(mut self) -> Fp {
+    pub(crate) fn mul_r_inv_internal(&mut self) {
         unsafe {
             wp1_precompiles::syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, R_INV.0.as_ptr() as *const u32);
         }
-        self
     }
 
     /// Internal function to multiply the internal representation by `R`, equivalent to transforming from
     /// a plain BigInt form back to the internal Montgomery form.
     /// Used as a bridge between the internal Montgomery representation and the zkvm precompiles.
     #[cfg(target_os = "zkvm")]
-    pub(crate) fn mul_r_internal(mut self) -> Fp {
+    pub(crate) fn mul_r_internal(&mut self) {
         unsafe {
             wp1_precompiles::syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, R.0.as_ptr() as *const u32);
         }
-        self
     }
 
     /// Squares this element.
@@ -681,7 +680,8 @@ impl Fp {
                 unsafe {
                     wp1_precompiles::syscall_bls12381_fp_mul(out.0.as_mut_ptr() as *mut u32, self.0.as_ptr() as *const u32);
                 }
-                out.mul_r_inv_internal()
+                out.mul_r_inv_internal();
+                out
             } else {
                 let (t1, carry) = mac(0, self.0[0], self.0[1], 0);
                 let (t2, carry) = mac(0, self.0[0], self.0[2], carry);

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -184,11 +184,9 @@ impl Fp2 {
     /// the internal Montgomery form to a plain BigInt form.
     /// Used as a bridge between the internal Montgomery representation and the zkvm precompiles.
     #[cfg(target_os = "zkvm")]
-    pub(crate) fn mul_r_inv_internal(self) -> Fp2 {
-        Fp2 {
-            c0: self.c0.mul_r_inv_internal(),
-            c1: self.c1.mul_r_inv_internal(),
-        }
+    pub(crate) fn mul_r_inv_internal(&mut self) {
+        self.c0.mul_r_inv_internal();
+        self.c1.mul_r_inv_internal();
     }
 
     pub fn square(&self) -> Fp2 {
@@ -198,7 +196,8 @@ impl Fp2 {
                 unsafe {
                     wp1_precompiles::syscall_bls12381_fp2_mul(out.c0.0.as_mut_ptr() as *mut u32, self.c0.0.as_ptr() as *const u32);
                 }
-                out.mul_r_inv_internal()
+                out.mul_r_inv_internal();
+                out
             } else {
                 // Complex squaring:
                 //
@@ -231,7 +230,8 @@ impl Fp2 {
                 unsafe {
                     wp1_precompiles::syscall_bls12381_fp2_mul(out.c0.0.as_mut_ptr() as *mut u32, rhs.c0.0.as_ptr() as *const u32);
                 }
-                out.mul_r_inv_internal()
+                out.mul_r_inv_internal();
+                out
             } else {
                 // F_{p^2} x F_{p^2} multiplication implemented with operand scanning (schoolbook)
                 // computes the result as:

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -8,7 +8,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use crate::fp::Fp;
 
 #[derive(Copy, Clone)]
-#[repr(C)] // NOTE: this might be *technically* required for ensuring the memory layout used in the zkvm is valid?
+#[repr(C)] // NOTE: this is technically required for ensuring the memory layout used in the zkvm precompiles is valid
 pub struct Fp2 {
     pub c0: Fp,
     pub c1: Fp,

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -452,24 +452,17 @@ impl G1Affine {
         cfg_if::cfg_if! {
             if #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))] {
                 // FIXME: this fails if self == rhs, would need to use syscall_bls12381_g1_double instead
-                let mut res = Self {
-                    x: self.x.mul_r_inv_internal(),
-                    y: self.y.mul_r_inv_internal(),
-                    infinity: self.infinity,
-                };
-                let other = Self {
-                    x: rhs.x.mul_r_inv_internal(),
-                    y: rhs.y.mul_r_inv_internal(),
-                    infinity: rhs.infinity,
-                };
+                let mut res = self.clone();
+                res.x.mul_r_inv_internal();
+                res.y.mul_r_inv_internal();
+                let mut other = rhs.clone();
+                other.x.mul_r_inv_internal();
+                other.y.mul_r_inv_internal();
                 unsafe {
                     wp1_precompiles::syscall_bls12381_g1_add(res.x.0.as_mut_ptr() as *mut u32, other.x.0.as_ptr() as *const u32);
                 }
-                let res = Self {
-                    x: res.x.mul_r_internal(),
-                    y: res.y.mul_r_internal(),
-                    infinity: res.infinity,
-                };
+                res.x.mul_r_internal();
+                res.y.mul_r_internal();
                 res
             } else {
                 let proj = G1Projective::from(rhs);

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -25,6 +25,7 @@ use crate::Scalar;
 /// "unchecked" API was misused.
 #[cfg_attr(docsrs, doc(cfg(feature = "groups")))]
 #[derive(Copy, Clone, Debug)]
+#[repr(C)] // NOTE: this is technically required for ensuring the memory layout used in the zkvm precompiles is valid
 pub struct G1Affine {
     pub x: Fp,
     pub y: Fp,

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -17,11 +17,6 @@ use group::WnafGroup;
 use crate::fp::Fp;
 use crate::Scalar;
 
-#[cfg(target_os = "zkvm")]
-extern "C" {
-    fn syscall_bls12381_g1_decompress(p: &mut [u8; 96]);
-}
-
 /// This is an element of $\mathbb{G}_1$ represented in the affine coordinate space.
 /// It is ideal to keep elements in this representation to reduce memory usage and
 /// improve performance through the use of mixed curve model arithmetic.
@@ -334,7 +329,7 @@ impl G1Affine {
                 let mut decompressed_g1 = [0u8; 96];
                 decompressed_g1[..48].copy_from_slice(bytes);
                 unsafe {
-                    syscall_bls12381_g1_decompress(&mut decompressed_g1);
+                    wp1_precompiles::syscall_bls12381_g1_decompress(&mut decompressed_g1);
                 }
                 Self::from_uncompressed_unchecked(&decompressed_g1).and_then(|p| CtOption::new(p, p.is_torsion_free()))
             } else {
@@ -356,7 +351,7 @@ impl G1Affine {
                 let mut decompressed_g1 = [0u8; 96];
                 decompressed_g1[..48].copy_from_slice(bytes);
                 unsafe {
-                    syscall_bls12381_g1_decompress(&mut decompressed_g1);
+                    wp1_precompiles::syscall_bls12381_g1_decompress(&mut decompressed_g1);
                 }
                 Self::from_uncompressed_unchecked(&decompressed_g1)
             } else {


### PR DESCRIPTION
This PR adds the `G1Affine::add_affine` function for usage with zkvm precompiles.

It also adds functions `mul_r_inv_internal` and `mul_r_internal` for going from/to the internal montgomery representation to a plain one. This replaces the previous `reduce_internal` function in `fp.rs`

This also adds an explicit dependency for the precompiles instead of using hardcoded `extern "C"` blocks.