### PR TITLE
fix: Properly handle P = -Q in add_affine

### DIFF
--- a/src/g1.rs
+++ b/src/g1.rs
@@ -459,26 +459,36 @@ impl G1Affine {
 
         cfg_if::cfg_if! {
             if #[cfg(target_os = "zkvm")] {
-                let mut res = self.clone();
-                res.x.mul_r_inv_internal();
-                res.y.mul_r_inv_internal();
-                // The add precompile only works when P != Q
-                if self != rhs {
+                // The add precompile only works when P != Q and P != -Q
+                if self.x != rhs.x {
+                    // In this case, we know that P != Q and P != -Q, since both Q and -Q have the same `x` coordinate
+                    let mut res = self.clone();
+                    res.x.mul_r_inv_internal();
+                    res.y.mul_r_inv_internal();
                     let mut other = rhs.clone();
                     other.x.mul_r_inv_internal();
                     other.y.mul_r_inv_internal();
                     unsafe {
                         syscall_bls12381_g1_add(res.x.0.as_mut_ptr() as *mut u32, other.x.0.as_ptr() as *const u32);
                     }
-                } else {
-                    // In this case, use the double precompile instead
+                    res.x.mul_r_internal();
+                    res.y.mul_r_internal();
+                    res
+                } else if self.y == rhs.y {
+                    // In this case, we know that P == Q, since both `x` and `y` are equal, so use the double precompile instead
+                    let mut res = self.clone();
+                    res.x.mul_r_inv_internal();
+                    res.y.mul_r_inv_internal();
                     unsafe {
                         syscall_bls12381_g1_double(res.x.0.as_mut_ptr() as *mut u32);
                     }
+                    res.x.mul_r_internal();
+                    res.y.mul_r_internal();
+                    res
+                } else {
+                    // In this case, we know that P == -Q, since `x` is equal but `y` is different, so we can just return the identity
+                    Self::identity()
                 }
-                res.x.mul_r_internal();
-                res.y.mul_r_internal();
-                res
             } else {
                 let proj = G1Projective::from(rhs);
                 let res = proj + self;

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -448,6 +448,7 @@ impl G1Affine {
     }
 
     /// Adds two affine points together.
+    /// This function assumes that both values are on the curve.
     /// In the zkvm context, this is accelerated with precompiles. In regular rust, this entails
     /// converting one of the points to projective coordinates and then converting the output back.
     pub fn add_affine(&self, rhs: &Self) -> Self {


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/lurk-lab/bls12_381/pull/8/files#r1587195797

I forgot the full conditions for the G1 add circuit to not divide by zero, which are `P != Q` and `P != -Q`. Since `-Q` is `Q` with its `y` coordinate flipped, this is still thankfully easy and cheap to check