### PR TITLE
zkvm: Remove unnecessary copies in miller loop and `sum_of_products`

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -398,17 +398,14 @@ impl Fp {
         Fp([r0, r1, r2, r3, r4, r5])
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn add_inp(&mut self, rhs: &Fp) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp_add(self.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
-                }
-            } else {
-                let _ = rhs;
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp_add(
+                self.0.as_mut_ptr() as *mut u32,
+                rhs.0.as_ptr() as *const u32,
+            );
         }
     }
 
@@ -471,17 +468,14 @@ impl Fp {
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn sub_inp(&mut self, rhs: &Fp) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp_sub(self.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
-                }
-            } else {
-                let _ = rhs;
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp_sub(
+                self.0.as_mut_ptr() as *mut u32,
+                rhs.0.as_ptr() as *const u32,
+            );
         }
     }
 
@@ -503,8 +497,8 @@ impl Fp {
     /// Returns `c = a.zip(b).fold(0, |acc, (a_i, b_i)| acc + a_i * b_i)`.
     ///
     /// Uses precompiles to calculate it naively but much more cheaply.
-    #[cfg(target_os = "zkvm")]
     #[inline]
+    #[cfg(target_os = "zkvm")]
     pub(crate) fn sum_of_products<const T: usize>(a: [Fp; T], b: [Fp; T]) -> Fp {
         let mut out = Fp::zero();
         for (mut ai, bi) in a.into_iter().zip(b) {
@@ -518,8 +512,8 @@ impl Fp {
     ///
     /// Implements Algorithm 2 from Patrick Longa's
     /// [ePrint 2022-367](https://eprint.iacr.org/2022/367) §3.
-    #[cfg(not(target_os = "zkvm"))]
     #[inline]
+    #[cfg(not(target_os = "zkvm"))]
     pub(crate) fn sum_of_products<const T: usize>(a: [Fp; T], b: [Fp; T]) -> Fp {
         // For a single `a x b` multiplication, operand scanning (schoolbook) takes each
         // limb of `a` in turn, and multiplies it by all of the limbs of `b` to compute
@@ -655,18 +649,15 @@ impl Fp {
     }
 
     #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn mul_inp(&mut self, rhs: &Fp) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
-                }
-                self.mul_r_inv_internal();
-            } else {
-                let _ = rhs;
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp_mul(
+                self.0.as_mut_ptr() as *mut u32,
+                rhs.0.as_ptr() as *const u32,
+            );
         }
+        self.mul_r_inv_internal();
     }
 
     #[inline]
@@ -730,6 +721,7 @@ impl Fp {
     /// Internal function to multiply the internal representation by `R_INV`, equivalent to transforming from
     /// the internal Montgomery form to a plain BigInt form.
     /// Used as a bridge between the internal Montgomery representation and the zkvm precompiles.
+    #[inline]
     #[cfg(target_os = "zkvm")]
     pub(crate) fn mul_r_inv_internal(&mut self) {
         unsafe {
@@ -743,6 +735,7 @@ impl Fp {
     /// Internal function to multiply the internal representation by `R`, equivalent to transforming from
     /// a plain BigInt form back to the internal Montgomery form.
     /// Used as a bridge between the internal Montgomery representation and the zkvm precompiles.
+    #[inline]
     #[cfg(target_os = "zkvm")]
     pub(crate) fn mul_r_internal(&mut self) {
         unsafe {
@@ -750,18 +743,16 @@ impl Fp {
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn square_inp(&mut self) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, self.0.as_ptr() as *const u32);
-                }
-                self.mul_r_inv_internal();
-            } else {
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp_mul(
+                self.0.as_mut_ptr() as *mut u32,
+                self.0.as_ptr() as *const u32,
+            );
         }
+        self.mul_r_inv_internal();
     }
 
     /// Squares this element.

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -499,11 +499,11 @@ impl Fp {
     /// Uses precompiles to calculate it naively but much more cheaply.
     #[inline]
     #[cfg(target_os = "zkvm")]
-    pub(crate) fn sum_of_products<const T: usize>(a: [Fp; T], b: [Fp; T]) -> Fp {
+    pub(crate) fn sum_of_products<const T: usize>(mut a: [Fp; T], b: [Fp; T]) -> Fp {
         let mut out = Fp::zero();
-        for (mut ai, bi) in a.into_iter().zip(b) {
-            ai.mul_inp(&bi);
-            out.add_inp(&ai);
+        for (ai, bi) in a.iter_mut().zip(b.iter()) {
+            ai.mul_inp(bi);
+            out.add_inp(ai);
         }
         out
     }

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -228,7 +228,7 @@ impl Fp {
 
     /// Converts an element of `Fp` into a byte representation in
     /// big-endian byte order.
-    pub fn to_bytes(self) -> [u8; 48] {
+    pub fn to_bytes(&self) -> [u8; 48] {
         // Turn into canonical form by computing
         // (a.R) / R = a
         let tmp = Fp::montgomery_reduce(
@@ -398,6 +398,20 @@ impl Fp {
         Fp([r0, r1, r2, r3, r4, r5])
     }
 
+    #[inline(always)]
+    pub fn add_inp(&mut self, rhs: &Fp) {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "zkvm")] {
+                unsafe {
+                    syscall_bls12381_fp_add(self.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
+                }
+            } else {
+                let _ = rhs;
+                unreachable!();
+            }
+        }
+    }
+
     #[inline]
     pub fn add(&self, rhs: &Fp) -> Fp {
         cfg_if::cfg_if! {
@@ -423,28 +437,52 @@ impl Fp {
     }
 
     #[inline]
-    pub const fn neg(&self) -> Fp {
-        let (d0, borrow) = sbb(MODULUS[0], self.0[0], 0);
-        let (d1, borrow) = sbb(MODULUS[1], self.0[1], borrow);
-        let (d2, borrow) = sbb(MODULUS[2], self.0[2], borrow);
-        let (d3, borrow) = sbb(MODULUS[3], self.0[3], borrow);
-        let (d4, borrow) = sbb(MODULUS[4], self.0[4], borrow);
-        let (d5, _) = sbb(MODULUS[5], self.0[5], borrow);
+    pub fn neg(&self) -> Fp {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "zkvm")] {
+                let mut out = Fp::zero();
+                unsafe {
+                    syscall_bls12381_fp_sub(out.0.as_mut_ptr() as *mut u32, self.0.as_ptr() as *const u32);
+                }
+                out
+            } else {
+                let (d0, borrow) = sbb(MODULUS[0], self.0[0], 0);
+                let (d1, borrow) = sbb(MODULUS[1], self.0[1], borrow);
+                let (d2, borrow) = sbb(MODULUS[2], self.0[2], borrow);
+                let (d3, borrow) = sbb(MODULUS[3], self.0[3], borrow);
+                let (d4, borrow) = sbb(MODULUS[4], self.0[4], borrow);
+                let (d5, _) = sbb(MODULUS[5], self.0[5], borrow);
 
-        // Let's use a mask if `self` was zero, which would mean
-        // the result of the subtraction is p.
-        let mask = (((self.0[0] | self.0[1] | self.0[2] | self.0[3] | self.0[4] | self.0[5]) == 0)
-            as u64)
-            .wrapping_sub(1);
+                // Let's use a mask if `self` was zero, which would mean
+                // the result of the subtraction is p.
+                let mask = (((self.0[0] | self.0[1] | self.0[2] | self.0[3] | self.0[4] | self.0[5]) == 0)
+                            as u64)
+                    .wrapping_sub(1);
 
-        Fp([
-            d0 & mask,
-            d1 & mask,
-            d2 & mask,
-            d3 & mask,
-            d4 & mask,
-            d5 & mask,
-        ])
+                Fp([
+                    d0 & mask,
+                    d1 & mask,
+                    d2 & mask,
+                    d3 & mask,
+                    d4 & mask,
+                    d5 & mask,
+                ])
+            }
+        }
+    }
+
+    #[inline(always)]
+    pub fn sub_inp(&mut self, rhs: &Fp) {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "zkvm")] {
+                unsafe {
+                    syscall_bls12381_fp_sub(self.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
+                }
+            } else {
+                let _ = rhs;
+                unreachable!();
+            }
+        }
     }
 
     #[inline]
@@ -469,8 +507,9 @@ impl Fp {
     #[inline]
     pub(crate) fn sum_of_products<const T: usize>(a: [Fp; T], b: [Fp; T]) -> Fp {
         let mut out = Fp::zero();
-        for (ai, bi) in a.into_iter().zip(b) {
-            out += ai * bi;
+        for (mut ai, bi) in a.into_iter().zip(b) {
+            ai.mul_inp(&bi);
+            out.add_inp(&ai);
         }
         out
     }
@@ -616,6 +655,21 @@ impl Fp {
     }
 
     #[inline]
+    pub fn mul_inp(&mut self, rhs: &Fp) {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "zkvm")] {
+                unsafe {
+                    syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, rhs.0.as_ptr() as *const u32);
+                }
+                self.mul_r_inv_internal();
+            } else {
+                let _ = rhs;
+                unreachable!();
+            }
+        }
+    }
+
+    #[inline]
     pub fn mul(&self, rhs: &Fp) -> Fp {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "zkvm")] {
@@ -693,6 +747,20 @@ impl Fp {
     pub(crate) fn mul_r_internal(&mut self) {
         unsafe {
             syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, R.0.as_ptr() as *const u32);
+        }
+    }
+
+    #[inline(always)]
+    pub fn square_inp(&mut self) {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "zkvm")] {
+                unsafe {
+                    syscall_bls12381_fp_mul(self.0.as_mut_ptr() as *mut u32, self.0.as_ptr() as *const u32);
+                }
+                self.mul_r_inv_internal();
+            } else {
+                unreachable!();
+            }
         }
     }
 

--- a/src/fp12.rs
+++ b/src/fp12.rs
@@ -113,6 +113,7 @@ impl Fp12 {
         }
     }
 
+    #[inline]
     #[cfg(target_os = "zkvm")]
     pub fn mul_by_014(&self, c0: &Fp2, c1: &Fp2, c4: &Fp2) -> Fp12 {
         let aa = self.c0.mul_by_01(c0, c1);
@@ -192,12 +193,7 @@ impl Fp12 {
     }
 
     #[inline]
-    pub fn square_inp(&mut self) {
-        todo!()
-    }
-
     #[cfg(target_os = "zkvm")]
-    #[inline]
     pub fn square(&self) -> Self {
         let ab = self.c0 * self.c1;
         let mut c0c1 = self.c0;
@@ -211,8 +207,8 @@ impl Fp12 {
         Fp12 { c0, c1: ab + ab }
     }
 
-    #[cfg(not(target_os = "zkvm"))]
     #[inline]
+    #[cfg(not(target_os = "zkvm"))]
     pub fn square(&self) -> Self {
         let ab = self.c0 * self.c1;
         let c0c1 = self.c0 + self.c1;

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -161,7 +161,8 @@ impl Fp2 {
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn mul_by_nonresidue_inp(&mut self) {
         // Multiply a + bu by u + 1, getting
         // au + a + bu^2 + bu
@@ -203,24 +204,23 @@ impl Fp2 {
     /// Internal function to multiply the internal representation by `R_INV`, equivalent to transforming from
     /// the internal Montgomery form to a plain BigInt form.
     /// Used as a bridge between the internal Montgomery representation and the zkvm precompiles.
+    #[inline]
     #[cfg(target_os = "zkvm")]
     pub(crate) fn mul_r_inv_internal(&mut self) {
         self.c0.mul_r_inv_internal();
         self.c1.mul_r_inv_internal();
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn square_inp(&mut self) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp2_mul(self.c0.0.as_mut_ptr() as *mut u32, self.c0.0.as_ptr() as *const u32);
-                }
-                self.mul_r_inv_internal();
-            } else {
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp2_mul(
+                self.c0.0.as_mut_ptr() as *mut u32,
+                self.c0.0.as_ptr() as *const u32,
+            );
         }
+        self.mul_r_inv_internal();
     }
 
     pub fn square(&self) -> Fp2 {
@@ -257,19 +257,16 @@ impl Fp2 {
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn mul_inp(&mut self, rhs: &Fp2) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp2_mul(self.c0.0.as_mut_ptr() as *mut u32, rhs.c0.0.as_ptr() as *const u32);
-                }
-                self.mul_r_inv_internal();
-            } else {
-                let _ = rhs;
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp2_mul(
+                self.c0.0.as_mut_ptr() as *mut u32,
+                rhs.c0.0.as_ptr() as *const u32,
+            );
         }
+        self.mul_r_inv_internal();
     }
 
     pub fn mul(&self, rhs: &Fp2) -> Fp2 {
@@ -302,30 +299,25 @@ impl Fp2 {
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn add_inp(&mut self, rhs: &Fp2) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp2_add(self.c0.0.as_mut_ptr() as *mut u32, rhs.c0.0.as_ptr() as *const u32);
-                }
-            } else {
-                let _ = rhs;
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp2_add(
+                self.c0.0.as_mut_ptr() as *mut u32,
+                rhs.c0.0.as_ptr() as *const u32,
+            );
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn double_inp(&mut self) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp2_add(self.c0.0.as_mut_ptr() as *mut u32, self.c0.0.as_ptr() as *const u32);
-                }
-            } else {
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp2_add(
+                self.c0.0.as_mut_ptr() as *mut u32,
+                self.c0.0.as_ptr() as *const u32,
+            );
         }
     }
 
@@ -346,17 +338,14 @@ impl Fp2 {
         }
     }
 
-    #[inline(always)]
+    #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn sub_inp(&mut self, rhs: &Fp2) {
-        cfg_if::cfg_if! {
-            if #[cfg(target_os = "zkvm")] {
-                unsafe {
-                    syscall_bls12381_fp2_sub(self.c0.0.as_mut_ptr() as *mut u32, rhs.c0.0.as_ptr() as *const u32);
-                }
-            } else {
-                let _ = rhs;
-                unreachable!();
-            }
+        unsafe {
+            syscall_bls12381_fp2_sub(
+                self.c0.0.as_mut_ptr() as *mut u32,
+                rhs.c0.0.as_ptr() as *const u32,
+            );
         }
     }
 

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -111,6 +111,7 @@ impl Fp6 {
     }
 
     #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn add_inp(&mut self, rhs: &Fp6) {
         self.c0.add_inp(&rhs.c0);
         self.c1.add_inp(&rhs.c1);
@@ -118,6 +119,7 @@ impl Fp6 {
     }
 
     #[inline]
+    #[cfg(target_os = "zkvm")]
     pub fn sub_inp(&mut self, rhs: &Fp6) {
         self.c0.sub_inp(&rhs.c0);
         self.c1.sub_inp(&rhs.c1);

--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -110,6 +110,20 @@ impl Fp6 {
         }
     }
 
+    #[inline]
+    pub fn add_inp(&mut self, rhs: &Fp6) {
+        self.c0.add_inp(&rhs.c0);
+        self.c1.add_inp(&rhs.c1);
+        self.c2.add_inp(&rhs.c2);
+    }
+
+    #[inline]
+    pub fn sub_inp(&mut self, rhs: &Fp6) {
+        self.c0.sub_inp(&rhs.c0);
+        self.c1.sub_inp(&rhs.c1);
+        self.c2.sub_inp(&rhs.c2);
+    }
+
     pub fn mul_by_1(&self, c1: &Fp2) -> Fp6 {
         Fp6 {
             c0: (self.c2 * c1).mul_by_nonresidue(),

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -815,34 +815,61 @@ fn doubling_step(r: &mut G2Projective) -> (Fp2, Fp2, Fp2) {
 #[cfg(target_os = "zkvm")]
 fn addition_step(r: &mut G2Projective, q: &G2Affine) -> (Fp2, Fp2, Fp2) {
     // Adaptation of Algorithm 27, https://eprint.iacr.org/2010/354.pdf
-    let zsquared = r.z.square();
-    let ysquared = q.y.square();
-    let t0 = zsquared * q.x;
-    let t1 = ((q.y + r.z).square() - ysquared - zsquared) * zsquared;
-    let t2 = t0 - r.x;
-    let t3 = t2.square();
-    let t4 = t3 + t3;
-    let t4 = t4 + t4;
-    let t5 = t4 * t2;
-    let t6 = t1 - r.y - r.y;
-    let t9 = t6 * q.x;
-    let t7 = t4 * r.x;
-    r.x = t6.square() - t5 - t7 - t7;
-    r.z = (r.z + t2).square() - zsquared - t3;
-    let t10 = q.y + r.z;
-    let t8 = (t7 - r.x) * t6;
-    let t0 = r.y * t5;
-    let t0 = t0 + t0;
-    r.y = t8 - t0;
-    let t10 = t10.square() - ysquared;
-    let ztsquared = r.z.square();
-    let t10 = t10 - ztsquared;
-    let t9 = t9 + t9 - t10;
-    let t10 = r.z + r.z;
-    let t6 = -t6;
-    let t1 = t6 + t6;
+    let mut zsquared = r.z;
+    zsquared.square_inp();
+    let mut ysquared = q.y;
+    ysquared.square_inp();
+    let mut t0 = q.y;
+    t0.add_inp(&r.z);
+    t0.square_inp();
+    t0.sub_inp(&ysquared);
+    t0.sub_inp(&zsquared);
+    t0.mul_inp(&zsquared);
+    let mut t1 = zsquared;
+    t1.mul_inp(&q.x);
+    t1.sub_inp(&r.x);
+    let mut t2 = t1;
+    t2.square_inp();
+    let mut t3 = t2;
+    t3.double_inp();
+    t3.double_inp();
+    let mut t4 = t3;
+    t4.mul_inp(&t1);
+    t0.sub_inp(&r.y);
+    t0.sub_inp(&r.y);
+    let mut t5 = t0;
+    t5.mul_inp(&q.x);
+    t3.mul_inp(&r.x);
+    r.x = t0;
+    r.x.square_inp();
+    r.x.sub_inp(&t4);
+    r.x.sub_inp(&t3);
+    r.x.sub_inp(&t3);
+    r.z.add_inp(&t1);
+    r.z.square_inp();
+    r.z.sub_inp(&zsquared);
+    r.z.sub_inp(&t2);
+    let mut t6 = q.y;
+    t6.add_inp(&r.z);
+    t3.sub_inp(&r.x);
+    t3.mul_inp(&t0);
+    t4.mul_inp(&r.y);
+    t4.double_inp();
+    r.y = t3;
+    r.y.sub_inp(&t4);
+    t6.square_inp();
+    t6.sub_inp(&ysquared);
+    let mut ztsquared = r.z;
+    ztsquared.square_inp();
+    t6.sub_inp(&ztsquared);
+    t5.double_inp();
+    t5.sub_inp(&t6);
+    let mut t6 = r.z;
+    t6.double_inp();
+    let mut t0 = -t0;
+    t0.double_inp();
 
-    (t10, t1, t9)
+    (t6, t0, t5)
 }
 
 #[cfg(not(target_os = "zkvm"))]

--- a/src/pairings.rs
+++ b/src/pairings.rs
@@ -46,7 +46,6 @@ impl MillerLoopResult {
     /// operation in the so-called `cyclotomic subgroup` of `Fq6` so that
     /// it can be compared with other elements of `Gt`.
     pub fn final_exponentiation(&self) -> Gt {
-        println!("cycle-tracker-start: final_exponentiation");
         #[must_use]
         fn fp4_square(a: Fp2, b: Fp2) -> (Fp2, Fp2) {
             let t0 = a.square();
@@ -140,8 +139,7 @@ impl MillerLoopResult {
             .frobenius_map()
             .frobenius_map()
             .frobenius_map();
-        let res = Gt(f
-            .invert()
+        Gt(f.invert()
             .map(|mut t1| {
                 let mut t2 = t0 * t1;
                 t1 = t2;
@@ -174,9 +172,7 @@ impl MillerLoopResult {
             // We unwrap() because `MillerLoopResult` can only be constructed
             // by a function within this crate, and we uphold the invariant
             // that the enclosed value is nonzero.
-            .unwrap());
-        println!("cycle-tracker-end: final_exponentiation");
-        res
+            .unwrap())
     }
 }
 
@@ -556,7 +552,6 @@ impl From<G2Affine> for G2Prepared {
 ///
 /// Requires the `alloc` and `pairing` crate features to be enabled.
 pub fn multi_miller_loop(terms: &[(&G1Affine, &G2Prepared)]) -> MillerLoopResult {
-    println!("cycle-tracker-start: multi_miller_loop");
     struct Adder<'a, 'b, 'c> {
         terms: &'c [(&'a G1Affine, &'b G2Prepared)],
         index: usize,
@@ -598,10 +593,7 @@ pub fn multi_miller_loop(terms: &[(&G1Affine, &G2Prepared)]) -> MillerLoopResult
 
     let mut adder = Adder { terms, index: 0 };
 
-    let tmp = miller_loop(&mut adder);
-    println!("cycle-tracker-start: multi_miller_loop");
-
-    MillerLoopResult(tmp)
+    MillerLoopResult(miller_loop(&mut adder))
 }
 
 /// Invoke the pairing function without the use of precomputation and other optimizations.
@@ -668,7 +660,6 @@ trait MillerLoopDriver {
 /// structure elsewhere; instead, we'll write concrete instantiations of
 /// `MillerLoopDriver` for whatever purposes we need (such as caching modes).
 fn miller_loop<D: MillerLoopDriver>(driver: &mut D) -> D::Output {
-    println!("cycle-tracker-start: miller_loop");
     let mut f = D::one();
 
     let mut found_one = false;
@@ -692,7 +683,6 @@ fn miller_loop<D: MillerLoopDriver>(driver: &mut D) -> D::Output {
     if BLS_X_IS_NEGATIVE {
         D::conjugate(&mut f);
     }
-    println!("cycle-tracker-end: miller_loop");
 
     f
 }


### PR DESCRIPTION
This PR removes unnecessary copies in the following hot paths:
* `Fp::sum_of_products`: remove the copies of `a` and `b` by using `iter_mut()` and `iter()`, also use `out` in-place
* Miller loop: both `doubling_step` and `addition_step` were rewritten to use the in-place operations and minimize the number of copies
* Some other minor miller loop copies were removed by using references in the `MillerLoopDriver` trait

This is achieved by adding zkvm-specific variants of base operations that modify a value in-place via `&mut self` to prevent unnecessary copies. Then functions in the hot-path are modified (adding a zkvm-specific variant) to use these operations instead where possible. We make a new function and use `#[cfg]` to select between the zkvm no-copy version and the regular version, to make it easier to compare implementations and ensure the functions are equivalent.

This brings the aptos-lc ratcheting test down from 22289711 cycles to 15933247 cycles (~29% reduction)

The other hot-paths that will be optimized in future follow-up PRs are:
* Removing copies in the `final_exponentiation` function and the functions it calls. This is currently taking around ~6M cycles
* `hash_to_curve`, specifically the `G2::mul_by_x()` operation could use G2 affine/double precompiles, which should save ~1M cycles