### PR TITLE
chore: mitigate copies in `final_exponentiation`

### DIFF
--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -153,12 +153,25 @@ impl Fp2 {
         self.conjugate()
     }
 
+    /// Raises this element to p.
+    #[inline]
+    pub fn frobenius_map_inp(&mut self) {
+        // This is always just a conjugation. If you're curious why, here's
+        // an article about it: https://alicebob.cryptoland.net/the-frobenius-endomorphism-with-finite-fields/
+        self.conjugate_inp()
+    }
+
     #[inline(always)]
     pub fn conjugate(&self) -> Self {
         Fp2 {
             c0: self.c0,
             c1: -self.c1,
         }
+    }
+
+    #[inline]
+    pub fn conjugate_inp(&mut self) {
+        self.c1 = -self.c1;
     }
 
     #[inline]


### PR DESCRIPTION
This PR applies the techniques from https://github.com/lurk-lab/bls12_381/pull/11 in order to further reduce copying in the hot path of pairing.