### PR TITLE
fix: speed up sqrt and inversion for FP, FP2, using unconstrained

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.check.command": "clippy"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "rust-analyzer.check.command": "clippy"
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ version = "1.4"
 default-features = false
 optional = true
 
+[dependencies.sphinx-zkvm]
+git = "https://github.com/argumentcomputer/sphinx"
+branch = "dev"
+optional = true
+
 [features]
 default = ["groups", "pairings", "alloc", "bits"]
 bits = ["ff/bits"]
@@ -74,3 +79,4 @@ pairings = ["groups", "pairing"]
 alloc = ["group/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
+zkvm = ["dep:sphinx-zkvm"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,12 @@ version = "1.4"
 default-features = false
 optional = true
 
-[dependencies.sphinx-zkvm]
-git = "https://github.com/argumentcomputer/sphinx"
-branch = "dev"
-optional = true
+# The sphinx-zkvm crate should only ever be a dependency in a target_os = zkvm context
+# See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies
+# Sphinx imports bls12_381 in a non-zkvm context, and bls12_381 imported sphinx in that context, it
+# could create a circular dependency.
+[target.'cfg(target_os = "zkvm")'.dependencies]
+sphinx-precompiles = { git = "https://github.com/argumentcomputer/sphinx", branch = "dev" }
 
 [features]
 default = ["groups", "pairings", "alloc", "bits"]
@@ -79,4 +81,3 @@ pairings = ["groups", "pairing"]
 alloc = ["group/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
-zkvm = ["dep:sphinx-zkvm"]

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -117,6 +117,54 @@ impl<'a, 'b> Mul<&'b Fp2> for &'a Fp2 {
 impl_binops_additive!(Fp2, Fp2);
 impl_binops_multiplicative!(Fp2, Fp2);
 
+macro_rules! sqrt_impl {
+    ($self:expr) => {{
+        CtOption::new(Fp2::zero(), $self.is_zero()).or_else(|| {
+            // a1 = self^((p - 3) / 4)
+            let a1 = $self.pow_vartime(&[
+                0xee7f_bfff_ffff_eaaa,
+                0x07aa_ffff_ac54_ffff,
+                0xd9cc_34a8_3dac_3d89,
+                0xd91d_d2e1_3ce1_44af,
+                0x92c6_e9ed_90d2_eb35,
+                0x0680_447a_8e5f_f9a6,
+            ]);
+
+            // alpha = a1^2 * self = self^((p - 3) / 2 + 1) = self^((p - 1) / 2)
+            let alpha = a1.square() * $self;
+
+            // x0 = self^((p + 1) / 4)
+            let x0 = a1 * $self;
+
+            // In the event that alpha = -1, the element is order p - 1 and so
+            // we're just trying to get the square of an element of the subfield
+            // Fp. This is given by x0 * u, since u = sqrt(-1). Since the element
+            // x0 = a + bu has b = 0, the solution is therefore au.
+            CtOption::new(
+                Fp2 {
+                    c0: -x0.c1,
+                    c1: x0.c0,
+                },
+                alpha.ct_eq(&(&Fp2::one()).neg()),
+            )
+            // Otherwise, the correct solution is (1 + alpha)^((q - 1) // 2) * x0
+            .or_else(|| {
+                CtOption::new(
+                    (alpha + Fp2::one()).pow_vartime(&[
+                        0xdcff_7fff_ffff_d555,
+                        0x0f55_ffff_58a9_ffff,
+                        0xb398_6950_7b58_7b12,
+                        0xb23b_a5c2_79c2_895f,
+                        0x258d_d3db_21a5_d66b,
+                        0x0d00_88f5_1cbf_f34d,
+                    ]) * x0,
+                    Choice::from(1),
+                )
+            })
+        })
+    }};
+}
+
 impl Fp2 {
     #[inline]
     pub const fn zero() -> Fp2 {
@@ -399,105 +447,37 @@ impl Fp2 {
     pub fn sqrt(&self) -> CtOption<Self> {
         // Algorithm 9, https://eprint.iacr.org/2012/685.pdf
         // with constant time modifications.
-
         cfg_if::cfg_if! {
-            // NOTE: the branches are meant to be identical except for the use of the unconstrained! macro
             if #[cfg(target_os = "zkvm")] {
-                let sqrt_option = unconstrained!(
-                    CtOption::new(Fp2::zero(), self.is_zero()).or_else(|| {
-                        // a1 = self^((p - 3) / 4)
-                        let a1 = self.pow_vartime(&[
-                            0xee7f_bfff_ffff_eaaa,
-                            0x07aa_ffff_ac54_ffff,
-                            0xd9cc_34a8_3dac_3d89,
-                            0xd91d_d2e1_3ce1_44af,
-                            0x92c6_e9ed_90d2_eb35,
-                            0x0680_447a_8e5f_f9a6,
-                        ]);
+                sphinx_precompiles::unconstrained! {
+                    let mut buf = [0u8; 97]; // Allocate 97 bytes to include the flag
+                    let sqrt_opt = sqrt_impl!(self);
+                    sqrt_opt.map(|root| {
+                        buf[0..48].copy_from_slice(&root.c0.to_bytes());
+                        buf[48..96].copy_from_slice(&root.c1.to_bytes());
+                        buf[97] = 1; // Set the flag to 1 indicating the result is valid
+                    });
+                    sphinx_precompiles::io::hint_slice(&buf);
+                }
 
-                        // alpha = a1^2 * self = self^((p - 3) / 2 + 1) = self^((p - 1) / 2)
-                        let alpha = a1.square() * self;
-
-                        // x0 = self^((p + 1) / 4)
-                        let x0 = a1 * self;
-
-                        // In the event that alpha = -1, the element is order p - 1 and so
-                        // we're just trying to get the square of an element of the subfield
-                        // Fp. This is given by x0 * u, since u = sqrt(-1). Since the element
-                        // x0 = a + bu has b = 0, the solution is therefore au.
-                        CtOption::new(
-                            Fp2 {
-                                c0: -x0.c1,
-                                c1: x0.c0,
-                            },
-                            alpha.ct_eq(&(&Fp2::one()).neg()),
-                        )
-                        // Otherwise, the correct solution is (1 + alpha)^((q - 1) // 2) * x0
-                        .or_else(|| {
-                            CtOption::new(
-                                (alpha + Fp2::one()).pow_vartime(&[
-                                    0xdcff_7fff_ffff_d555,
-                                    0x0f55_ffff_58a9_ffff,
-                                    0xb398_6950_7b58_7b12,
-                                    0xb23b_a5c2_79c2_895f,
-                                    0x258d_d3db_21a5_d66b,
-                                    0x0d00_88f5_1cbf_f34d,
-                                ]) * x0,
-                                Choice::from(1),
-                            )
-                        })
-                    })
-                );
+                let byte_vec = sphinx_precompiles::io::read_vec();
+                let bytes: [u8; 97] = byte_vec.try_into().unwrap();
+                match bytes[96] {
+                    0 => CtOption::new(Fp2::zero(), Choice::from(0u8)), // Return None if the flag is 0
+                    _ => {
+                        let c0 = Fp::from_bytes(&bytes[0..48].try_into().unwrap()).unwrap();
+                        let c1 = Fp::from_bytes(&bytes[48..96].try_into().unwrap()).unwrap();
+                        let root = Fp2 { c0, c1 };
+                        CtOption::new(root, !self.is_zero() & (root * root).ct_eq(self))
+                    }
+                }
             } else {
-                let sqrt_option = CtOption::new(Fp2::zero(), self.is_zero()).or_else(|| {
-                // a1 = self^((p - 3) / 4)
-                let a1 = self.pow_vartime(&[
-                    0xee7f_bfff_ffff_eaaa,
-                    0x07aa_ffff_ac54_ffff,
-                    0xd9cc_34a8_3dac_3d89,
-                    0xd91d_d2e1_3ce1_44af,
-                    0x92c6_e9ed_90d2_eb35,
-                    0x0680_447a_8e5f_f9a6,
-                ]);
-
-                // alpha = a1^2 * self = self^((p - 3) / 2 + 1) = self^((p - 1) / 2)
-                let alpha = a1.square() * self;
-
-                // x0 = self^((p + 1) / 4)
-                let x0 = a1 * self;
-
-                // In the event that alpha = -1, the element is order p - 1 and so
-                // we're just trying to get the square of an element of the subfield
-                // Fp. This is given by x0 * u, since u = sqrt(-1). Since the element
-                // x0 = a + bu has b = 0, the solution is therefore au.
-                CtOption::new(
-                    Fp2 {
-                        c0: -x0.c1,
-                        c1: x0.c0,
-                    },
-                    alpha.ct_eq(&(&Fp2::one()).neg()),
-                )
-                // Otherwise, the correct solution is (1 + alpha)^((q - 1) // 2) * x0
-                .or_else(|| {
-                    CtOption::new(
-                        (alpha + Fp2::one()).pow_vartime(&[
-                            0xdcff_7fff_ffff_d555,
-                            0x0f55_ffff_58a9_ffff,
-                            0xb398_6950_7b58_7b12,
-                            0xb23b_a5c2_79c2_895f,
-                            0x258d_d3db_21a5_d66b,
-                            0x0d00_88f5_1cbf_f34d,
-                        ]) * x0,
-                        Choice::from(1),
-                    )
-                })
-                });
+                let sqrt_option: CtOption<Self> = sqrt_impl!(self);
+                // Only return the result if it's really the square root (and so
+                // self is actually quadratic nonresidue)
+                sqrt_option.and_then(|sqrt| CtOption::new(sqrt, sqrt.square().ct_eq(self)))
             }
         }
-
-        // Only return the result if it's really the square root (and so
-        // self is actually quadratic nonresidue)
-        sqrt_option.and_then(|sqrt| CtOption::new(sqrt, sqrt.square().ct_eq(self)))
     }
 
     /// Computes the multiplicative inverse of this field

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -400,52 +400,104 @@ impl Fp2 {
         // Algorithm 9, https://eprint.iacr.org/2012/685.pdf
         // with constant time modifications.
 
-        CtOption::new(Fp2::zero(), self.is_zero()).or_else(|| {
-            // a1 = self^((p - 3) / 4)
-            let a1 = self.pow_vartime(&[
-                0xee7f_bfff_ffff_eaaa,
-                0x07aa_ffff_ac54_ffff,
-                0xd9cc_34a8_3dac_3d89,
-                0xd91d_d2e1_3ce1_44af,
-                0x92c6_e9ed_90d2_eb35,
-                0x0680_447a_8e5f_f9a6,
-            ]);
+        cfg_if::cfg_if! {
+            // NOTE: the branches are meant to be identical except for the use of the unconstrained! macro
+            if #[cfg(target_os = "zkvm")] {
+                let sqrt_option = unconstrained!(
+                    CtOption::new(Fp2::zero(), self.is_zero()).or_else(|| {
+                        // a1 = self^((p - 3) / 4)
+                        let a1 = self.pow_vartime(&[
+                            0xee7f_bfff_ffff_eaaa,
+                            0x07aa_ffff_ac54_ffff,
+                            0xd9cc_34a8_3dac_3d89,
+                            0xd91d_d2e1_3ce1_44af,
+                            0x92c6_e9ed_90d2_eb35,
+                            0x0680_447a_8e5f_f9a6,
+                        ]);
 
-            // alpha = a1^2 * self = self^((p - 3) / 2 + 1) = self^((p - 1) / 2)
-            let alpha = a1.square() * self;
+                        // alpha = a1^2 * self = self^((p - 3) / 2 + 1) = self^((p - 1) / 2)
+                        let alpha = a1.square() * self;
 
-            // x0 = self^((p + 1) / 4)
-            let x0 = a1 * self;
+                        // x0 = self^((p + 1) / 4)
+                        let x0 = a1 * self;
 
-            // In the event that alpha = -1, the element is order p - 1 and so
-            // we're just trying to get the square of an element of the subfield
-            // Fp. This is given by x0 * u, since u = sqrt(-1). Since the element
-            // x0 = a + bu has b = 0, the solution is therefore au.
-            CtOption::new(
-                Fp2 {
-                    c0: -x0.c1,
-                    c1: x0.c0,
-                },
-                alpha.ct_eq(&(&Fp2::one()).neg()),
-            )
-            // Otherwise, the correct solution is (1 + alpha)^((q - 1) // 2) * x0
-            .or_else(|| {
+                        // In the event that alpha = -1, the element is order p - 1 and so
+                        // we're just trying to get the square of an element of the subfield
+                        // Fp. This is given by x0 * u, since u = sqrt(-1). Since the element
+                        // x0 = a + bu has b = 0, the solution is therefore au.
+                        CtOption::new(
+                            Fp2 {
+                                c0: -x0.c1,
+                                c1: x0.c0,
+                            },
+                            alpha.ct_eq(&(&Fp2::one()).neg()),
+                        )
+                        // Otherwise, the correct solution is (1 + alpha)^((q - 1) // 2) * x0
+                        .or_else(|| {
+                            CtOption::new(
+                                (alpha + Fp2::one()).pow_vartime(&[
+                                    0xdcff_7fff_ffff_d555,
+                                    0x0f55_ffff_58a9_ffff,
+                                    0xb398_6950_7b58_7b12,
+                                    0xb23b_a5c2_79c2_895f,
+                                    0x258d_d3db_21a5_d66b,
+                                    0x0d00_88f5_1cbf_f34d,
+                                ]) * x0,
+                                Choice::from(1),
+                            )
+                        })
+                    })
+                );
+            } else {
+                let sqrt_option = CtOption::new(Fp2::zero(), self.is_zero()).or_else(|| {
+                // a1 = self^((p - 3) / 4)
+                let a1 = self.pow_vartime(&[
+                    0xee7f_bfff_ffff_eaaa,
+                    0x07aa_ffff_ac54_ffff,
+                    0xd9cc_34a8_3dac_3d89,
+                    0xd91d_d2e1_3ce1_44af,
+                    0x92c6_e9ed_90d2_eb35,
+                    0x0680_447a_8e5f_f9a6,
+                ]);
+
+                // alpha = a1^2 * self = self^((p - 3) / 2 + 1) = self^((p - 1) / 2)
+                let alpha = a1.square() * self;
+
+                // x0 = self^((p + 1) / 4)
+                let x0 = a1 * self;
+
+                // In the event that alpha = -1, the element is order p - 1 and so
+                // we're just trying to get the square of an element of the subfield
+                // Fp. This is given by x0 * u, since u = sqrt(-1). Since the element
+                // x0 = a + bu has b = 0, the solution is therefore au.
                 CtOption::new(
-                    (alpha + Fp2::one()).pow_vartime(&[
-                        0xdcff_7fff_ffff_d555,
-                        0x0f55_ffff_58a9_ffff,
-                        0xb398_6950_7b58_7b12,
-                        0xb23b_a5c2_79c2_895f,
-                        0x258d_d3db_21a5_d66b,
-                        0x0d00_88f5_1cbf_f34d,
-                    ]) * x0,
-                    Choice::from(1),
+                    Fp2 {
+                        c0: -x0.c1,
+                        c1: x0.c0,
+                    },
+                    alpha.ct_eq(&(&Fp2::one()).neg()),
                 )
-            })
-            // Only return the result if it's really the square root (and so
-            // self is actually quadratic nonresidue)
-            .and_then(|sqrt| CtOption::new(sqrt, sqrt.square().ct_eq(self)))
-        })
+                // Otherwise, the correct solution is (1 + alpha)^((q - 1) // 2) * x0
+                .or_else(|| {
+                    CtOption::new(
+                        (alpha + Fp2::one()).pow_vartime(&[
+                            0xdcff_7fff_ffff_d555,
+                            0x0f55_ffff_58a9_ffff,
+                            0xb398_6950_7b58_7b12,
+                            0xb23b_a5c2_79c2_895f,
+                            0x258d_d3db_21a5_d66b,
+                            0x0d00_88f5_1cbf_f34d,
+                        ]) * x0,
+                        Choice::from(1),
+                    )
+                })
+                });
+            }
+        }
+
+        // Only return the result if it's really the square root (and so
+        // self is actually quadratic nonresidue)
+        sqrt_option.and_then(|sqrt| CtOption::new(sqrt, sqrt.square().ct_eq(self)))
     }
 
     /// Computes the multiplicative inverse of this field


### PR DESCRIPTION
- Added new optional 'sphinx-zkvm' dependency and 'zkvm' feature in Cargo.toml
- Modified `sqrt` method in `Fp2` file, adding differentiated execution logic based on the `target_os`
- Adjusted `Fp2` operations to handle quadratic nonresidue during the square root computation effectively and to conform to environment specifications.

This is just a thought experiment: it seems we're not actively using either.