### PR TITLE
refactor: Refactor and test Fp6 multiplication for Zkvm OS

### DIFF
--- a/src/fp6.rs
+++ b/src/fp6.rs
@@ -742,8 +742,8 @@ mod tests {
 
     #[test]
     fn fuzz_mul_interleaved() {
+        let mut rng = rand_xorshift::XorShiftRng::from_seed(SEED);
         for _i in 0..TEST_ITER {
-            let mut rng = rand_xorshift::XorShiftRng::from_seed(SEED);
             let a = Fp6::random(&mut rng);
             let b = Fp6::random(&mut rng);
 


### PR DESCRIPTION
- Refactored the `mul_interleaved` function in the `Fp6` struct, moving code for `target_os != "zkvm"` to a new `mul_interleaved_default` function,
- Added a test module for the `mul_interleaved` function, including a new function `mul_interleaved_zkvm_test` and a test case `fuzz_mul_interleaved` for function validation.